### PR TITLE
implement github actions for helm charts

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,8 @@
+remote: origin
+target-branch: master
+helm-extra-args: --timeout 600s
+chart-dirs:
+  - charts
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+  - k8s-at-home=https://k8s-at-home.com/charts

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -3,6 +3,3 @@ target-branch: master
 helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
-  - k8s-at-home=https://k8s-at-home.com/charts

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,46 @@
+name: Lint and Test Charts
+
+on:
+  pull_request:
+    paths:
+    - 'charts/**'
+    - '!charts/**/README.md'
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config .github/ct.yaml --excluded-charts ""
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.1.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config .github/ct.yaml --excluded-charts ""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,83 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'charts/**'
+      - '!charts/**/README.md'
+
+jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Block concurrent jobs
+        uses: softprops/turnstyle@v1
+        with:
+          continue-after-seconds: 180
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    needs: pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_repo_url: https://blakeblackshear.github.io/blakeshome-charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  # Update the generated timestamp in the index.yaml
+  # needed until https://github.com/helm/chart-releaser/issues/90
+  # or helm/chart-releaser-action supports this
+  post-release:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block concurrent jobs
+        uses: softprops/turnstyle@v1
+        with:
+          continue-after-seconds: 180
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: "gh-pages"
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Commit and push timestamp updates
+        run: |
+          if [[ -f index.yaml ]]; then
+            git pull
+            export generated_date=$(date --utc +%FT%T.%9NZ)
+            sed -i -e "s/^generated:.*/generated: \"$generated_date\"/" index.yaml
+            git add index.yaml
+            git commit -sm "Update generated timestamp [ci-skip]" || exit 0
+            git push
+          fi


### PR DESCRIPTION
This PR should add the necessary github actions to lint, test, and release charts as they are added and changed.  This is part of the solve for https://github.com/blakeblackshear/frigate/issues/156

* For every PR impacting the helm chart, a linter will make sure that the change passes linting which includes forcing a version bump on changes)
* For every PR impacting the helm chart, a 'kubernetes in docker' (KIND) cluster will be temporarily created and the chart will be installed to that test cluster to ensure that it installs properly
* For every merge to master impacting the helm chart, automation will package the chart, update the `index.yaml` on the `gh-pages` branch, and cut a github release with the packaged chart for reference as a chart repository.

This also assumes that the gh-pages for the repo will be published to https://blakeblackshear.github.io/blakeshome-charts - if it should be different, we will need to update `release.yaml` as appropriate.

**ACTION REQUIRED:**

* Github Pages should be enabled within the repo settings. Please use the default `gh-pages` branch
