### PR TITLE
initial inclusion of frigate chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-README
+# blakeshome-charts
+
+[![](https://github.com/blakeblackshear/blakeshome-charts/workflows/Release%20Charts/badge.svg?branch=master)](https://github.com/blakeblackshear/blakeshome-charts/actions)
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add blakeshome https://blakeblackshear.github.io/blakeshome-charts/
+```
+
+You can then run `helm search repo blakeshome` to see the charts.
+
+## Charts
+tt
+* [minecraft](https://github.com/blakeblackshear/minecraft-server-charts/tree/master/charts/minecraft)

--- a/charts/frigate/.helmignore
+++ b/charts/frigate/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: "0.8.0"
+description: NVR With Realtime Object Detection for IP Cameras
+name: frigate
+version: 5.0.0
+keywords:
+  - tensorflow
+  - coral
+  - ml
+home: https://github.com/blakeblackshear/blakeshome-charts/tree/master/charts/frigate
+icon: https://github.com/blakeblackshear/frigate/blob/master/docs/static/img/frigate.png
+sources:
+  - https://github.com/blakeblackshear/frigate
+maintainers:
+  - name: blakeblackshear
+    email: blakeb@blakeshome.com
+  - name: billimek
+    email: jeff@billimek.com

--- a/charts/frigate/OWNERS
+++ b/charts/frigate/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- blakeblackshear
+- billimek
+reviewers:
+- blakeblackshear
+- billimek

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -11,17 +11,13 @@ $ helm install blakeshome/frigate
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+To install the chart with the release name `frigate`:
 
 ```console
-helm install --name my-release blakeshome/frigate
+helm install frigate blakeshome/frigate
 ```
 
-~~**IMPORTANT NOTE:** the [Google Coral USB Accelerator](https://coral.withgoogle.com/products/accelerator/) must be accessible on the node where this pod runs, in order for this chart to function properly.~~
-
-The Coral USB device is now optional
-
-A way to achieve this can be with nodeAffinity rules, for example:
+If using the Coral USB TPU module (strongly recommended), you can use `nodeAffinity` rules to designate which node the pod is scheduled to in order to have host-access to the device, for example:
 
 ```yaml
 affinity:
@@ -39,61 +35,28 @@ affinity:
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall/delete the `frigate` deployment:
 
 ```console
-helm delete my-release --purge
+helm delete frigate
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Frigate chart and their default values.
-
-| Parameter                  | Description                         | Default                                                 |
-|----------------------------|-------------------------------------|---------------------------------------------------------|
-| `image.repository`         | Image repository | `blakeblackshear/frigate` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/blakeblackshear/frigate/tags/).| `0.8.0`|
-| `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
-| `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
-| `timezone`                 | Timezone the frigate instance should run as, e.g. 'America/New_York' | `UTC` |
-| `rtspPassword`             | Password to use for RTSP cameras | `password` |
-| `extraSecretForEnvFrom`    | Secrets containing env variables for  | `[]` |
-| `coral.enabled`            | Use the Coral USB device | `false` |
-| `coral.hostPath`           | Host Path to reference USB device location (on the host) | `/dev/bus/usb` |
-| `masksConfigMap`           | Reference to existing ConfigMap that contains camera masks - [more info](https://github.com/blakeblackshear/frigate#masks-and-limiting-detection-to-a-certain-area) | `{}` |
-| `shmSize`                  | Shared memory size for processing | `1Gi` |
-| `config`                   | frigate configuration - see [config.yaml](https://github.com/blakeblackshear/frigate/blob/master/config/config.yml) for example  | `{}` |
-| `Service.type`          | Kubernetes service type for the frigate GUI | `ClusterIP` |
-| `Service.port`          | Kubernetes port where the frigate GUI is exposed| `5000` |
-| `Service.annotations`   | Service annotations for the frigate GUI | `{}` |
-| `Service.labels`        | Custom labels | `{}` |
-| `Service.loadBalancerIP` | Loadbalance IP for the frigate GUI | `{}` |
-| `Service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)      | None
-| `ingress.enabled`              | Enables Ingress | `false` |
-| `ingress.annotations`          | Ingress annotations | `{}` |
-| `ingress.labels`               | Custom labels                       | `{}`
-| `ingress.path`                 | Ingress path | `/` |
-| `ingress.hosts`                | Ingress accepted hostnames | `chart-example.local` |
-| `ingress.tls`                  | Ingress TLS configuration | `[]` |
-| `resources`                | CPU/Memory resource requests/limits | `{}` |
-| `nodeSelector`             | Node labels for pod assignment | `{}` |
-| `tolerations`              | Toleration labels for pod assignment | `[]` |
-| `affinity`                 | Affinity settings for pod assignment | `{}` |
+Read through the [values.yaml](https://github.com/blakeblackshear/blakeshome-charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-helm install --name my-release \
-  --set rtspPassword="nosecrets" \
-    k8s-at-home/frigate
+helm install frigate \
+  --set rtspPassword="someValue" \
+    blakeshome/frigate
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml blakeshome/frigate
+helm install --name frigate -f values.yaml blakeshome/frigate
 ```
-
-Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -1,0 +1,99 @@
+# Frigate - NVR With Realtime Object Detection for IP Cameras
+
+This is a helm chart for [frigate](https://github.com/blakeblackshear/frigate)
+
+## TL;DR;
+
+```shell
+$ helm repo add blakeshome https://blakeblackshear.github.io/blakeshome-charts/
+$ helm install blakeshome/frigate
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release blakeshome/frigate
+```
+
+~~**IMPORTANT NOTE:** the [Google Coral USB Accelerator](https://coral.withgoogle.com/products/accelerator/) must be accessible on the node where this pod runs, in order for this chart to function properly.~~
+
+The Coral USB device is now optional
+
+A way to achieve this can be with nodeAffinity rules, for example:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: tpu
+          operator: In
+          values:
+          - google-coral
+```
+
+... where a node with an attached Coral USB device is labeled with `tpu: google-coral`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Frigate chart and their default values.
+
+| Parameter                  | Description                         | Default                                                 |
+|----------------------------|-------------------------------------|---------------------------------------------------------|
+| `image.repository`         | Image repository | `blakeblackshear/frigate` |
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/blakeblackshear/frigate/tags/).| `0.8.0`|
+| `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
+| `timezone`                 | Timezone the frigate instance should run as, e.g. 'America/New_York' | `UTC` |
+| `rtspPassword`             | Password to use for RTSP cameras | `password` |
+| `extraSecretForEnvFrom`    | Secrets containing env variables for  | `[]` |
+| `coral.enabled`            | Use the Coral USB device | `false` |
+| `coral.hostPath`           | Host Path to reference USB device location (on the host) | `/dev/bus/usb` |
+| `masksConfigMap`           | Reference to existing ConfigMap that contains camera masks - [more info](https://github.com/blakeblackshear/frigate#masks-and-limiting-detection-to-a-certain-area) | `{}` |
+| `shmSize`                  | Shared memory size for processing | `1Gi` |
+| `config`                   | frigate configuration - see [config.yaml](https://github.com/blakeblackshear/frigate/blob/master/config/config.yml) for example  | `{}` |
+| `Service.type`          | Kubernetes service type for the frigate GUI | `ClusterIP` |
+| `Service.port`          | Kubernetes port where the frigate GUI is exposed| `5000` |
+| `Service.annotations`   | Service annotations for the frigate GUI | `{}` |
+| `Service.labels`        | Custom labels | `{}` |
+| `Service.loadBalancerIP` | Loadbalance IP for the frigate GUI | `{}` |
+| `Service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)      | None
+| `ingress.enabled`              | Enables Ingress | `false` |
+| `ingress.annotations`          | Ingress annotations | `{}` |
+| `ingress.labels`               | Custom labels                       | `{}`
+| `ingress.path`                 | Ingress path | `/` |
+| `ingress.hosts`                | Ingress accepted hostnames | `chart-example.local` |
+| `ingress.tls`                  | Ingress TLS configuration | `[]` |
+| `resources`                | CPU/Memory resource requests/limits | `{}` |
+| `nodeSelector`             | Node labels for pod assignment | `{}` |
+| `tolerations`              | Toleration labels for pod assignment | `[]` |
+| `affinity`                 | Affinity settings for pod assignment | `{}` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name my-release \
+  --set rtspPassword="nosecrets" \
+    k8s-at-home/frigate
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name my-release -f values.yaml blakeshome/frigate
+```
+
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.

--- a/charts/frigate/ci/ci-values.yaml
+++ b/charts/frigate/ci/ci-values.yaml
@@ -1,0 +1,16 @@
+# Probes configuration
+probes:
+  liveness:
+    enabled: false
+  readiness:
+    enabled: false
+  startup:
+    enabled: false
+
+config: |
+  mqtt:
+    host: test.mosquitto.org
+    topic_prefix: frigate
+  detectors:
+    cpu1:
+      type: cpu

--- a/charts/frigate/templates/NOTES.txt
+++ b/charts/frigate/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "frigate.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "frigate.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "frigate.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "frigate.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:5000 to use your application"
+  kubectl port-forward $POD_NAME 5000:5000
+{{- end }}

--- a/charts/frigate/templates/_helpers.tpl
+++ b/charts/frigate/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "frigate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "frigate.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "frigate.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "frigate.labels" -}}
+app.kubernetes.io/name: {{ include "frigate.name" . }}
+helm.sh/chart: {{ include "frigate.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/frigate/templates/configmap.yaml
+++ b/charts/frigate/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "frigate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "frigate.name" . }}
+    helm.sh/chart: {{ include "frigate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  config.yml: |
+{{ .Values.config | indent 4 }}

--- a/charts/frigate/templates/data-pvc.yaml
+++ b/charts/frigate/templates/data-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "frigate.fullname" . }}-data
+  {{- if .Values.persistence.data.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "frigate.name" . }}
+    helm.sh/chart: {{ include "frigate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+{{- if .Values.persistence.data.storageClass }}
+{{- if (eq "-" .Values.persistence.data.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.data.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "frigate.fullname" . }}
+  labels:
+{{ include "frigate.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 3
+  strategy:
+    type: {{ .Values.strategyType }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "frigate.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "frigate.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.podAnnotations }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      initContainers:
+        - name: config
+          securityContext:
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /frigate-config
+              name: configmap
+            - mountPath: /masks
+              name: masks
+            - mountPath: /config
+              name: config
+              readOnly: false
+            - mountPath: /media
+              name: media
+              readOnly: false
+          command: ['sh', '-c']
+          args:
+            - cp /frigate-config/* /config;
+              {{- if .Values.masksConfigMap }}
+              cp /masks/* /config;
+              {{- end }}
+
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+            - name: rtmp
+              containerPort: 1935
+              protocol: TCP
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          {{- end }}
+          env:
+            {{- if .Values.timezone }}
+            - name: TZ
+              value: "{{ .Values.timezone }}"
+            {{- end }}
+            - name: FRIGATE_RTSP_PASSWORD
+              value: "{{ .Values.rtspPassword }}"
+          envFrom:
+          {{- range .Values.extraSecretForEnvFrom }}
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.coral.enabled }}
+            - mountPath: /dev/bus/usb
+              name: usb
+            {{- end }}
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+            - name: dshm
+              mountPath: /dev/shm
+            {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          emptyDir: {}
+        - name: configmap
+          configMap:
+            name: {{ template "frigate.fullname" . }}
+        - name: masks
+          {{- if .Values.masksConfigMap }}
+          configMap:
+            name: {{ .Values.masksConfigMap }}
+          {{- else }}
+          emptyDir:
+            {}
+          {{- end }}
+        {{- if .Values.coral.enabled }}
+        - name: usb
+          hostPath:
+            path: {{ .Values.coral.hostPath }}
+        {{- end }}
+        - name: data
+        {{- if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.data.existingClaim }}{{ .Values.persistence.data.existingClaim }}{{- else }}{{ template "frigate.fullname" . }}-data{{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.shmSize }}
+        {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -44,8 +44,8 @@ spec:
             - mountPath: /config
               name: config
               readOnly: false
-            - mountPath: /media
-              name: media
+            - mountPath: /data
+              name: data
               readOnly: false
           command: ['sh', '-c']
           args:

--- a/charts/frigate/templates/ingress.yaml
+++ b/charts/frigate/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "frigate.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "frigate.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/frigate/templates/service.yaml
+++ b/charts/frigate/templates/service.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "frigate.fullname" . }}
+  labels:
+{{ include "frigate.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+    - name: rtmp
+      port: 1935
+      protocol: TCP
+      targetPort: rtmp
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+  selector:
+    app.kubernetes.io/name: {{ include "frigate.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -137,7 +137,7 @@ ingress:
 
 persistence:
   data:
-    enabled: true
+    enabled: false
     ## frigate configuration data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -9,7 +9,7 @@ strategyType: Recreate
 
 image:
   repository: blakeblackshear/frigate
-  tag: 0.8.0
+  tag: 0.8.0-amd64
   pullPolicy: IfNotPresent
 
 rtspPassword: password
@@ -71,18 +71,18 @@ config: |
     # cpu1:
     #   type: cpu
 
-  cameras:
-    # Name of your camera
-    front_door:
-      ffmpeg:
-        inputs:
-          - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
-            roles:
-              - detect
-              - rtmp
-      width: 1280
-      height: 720
-      fps: 5
+  # cameras:
+  #   # Name of your camera
+  #   front_door:
+  #     ffmpeg:
+  #       inputs:
+  #         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
+  #           roles:
+  #             - detect
+  #             - rtmp
+  #     width: 1280
+  #     height: 720
+  #     fps: 5
 
 # Probes configuration
 probes:

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -1,0 +1,177 @@
+# Default values for frigate.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
+
+image:
+  repository: blakeblackshear/frigate
+  tag: 0.8.0
+  pullPolicy: IfNotPresent
+
+rtspPassword: password
+
+# secret name containing environment variables for frigate
+extraSecretForEnvFrom: []
+
+coral:
+  enabled: false
+  hostPath: /dev/bus/usb
+
+# Specify image that generates the config folder containing the Frigate config file, masks (if specified), etc.
+initContainer:
+  image:
+    repository: busybox
+    tag: latest
+    pullPolicy: Always
+
+# reference to configMap that contains the binary data of the masks to be copied into the container
+# this requires that generateConfigFolder.enabled = true
+# see https://github.com/blakeblackshear/frigate#masks-and-limiting-detection-to-a-certain-area for more info
+masksConfigMap: {}
+
+extraVolumes: []
+extraVolumeMounts: []
+
+shmSize: 1Gi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# frigate configuration - see https://blakeblackshear.github.io/frigate/configuration/index for example
+config: |
+  mqtt:
+    # Required: host name
+    host: mqtt.server.com
+    # Optional: port (default: shown below)
+    port: 1883
+    # Optional: topic prefix (default: shown below)
+    # WARNING: must be unique if you are running multiple instances
+    topic_prefix: frigate
+    # Optional: client id (default: shown below)
+    # WARNING: must be unique if you are running multiple instances
+    client_id: frigate
+    # Optional: user
+    user: mqtt_user
+    # Optional: password
+    # NOTE: Environment variables that begin with 'FRIGATE_' may be referenced in {}.
+    #       eg. password: '{FRIGATE_MQTT_PASSWORD}'
+    password: password
+    # Optional: interval in seconds for publishing stats (default: shown below)
+    stats_interval: 60
+
+  detectors:
+    coral:
+      type: edgetpu
+      device: usb
+    # cpu1:
+    #   type: cpu
+
+  cameras:
+    # Name of your camera
+    front_door:
+      ffmpeg:
+        inputs:
+          - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
+            roles:
+              - detect
+              - rtmp
+      width: 1280
+      height: 720
+      fps: 5
+
+# Probes configuration
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    timeoutSeconds: 10
+  readiness:
+    enabled: true
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    timeoutSeconds: 10
+  startup:
+    enabled: false
+    failureThreshold: 30
+    periodSeconds: 10
+
+service:
+  type: ClusterIP
+  port: 5000
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  labels: {}
+  ## Use loadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  loadBalancerIP:
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+persistence:
+  data:
+    enabled: true
+    ## frigate configuration data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
This should add the frigate helm chart.  ~~Some updates to the readme are still necessary before a merge.~~

Closes https://github.com/blakeblackshear/frigate/issues/156

Important notes:

* The chart major version was bumped to help differentiate this chart from the parent  https://github.com/k8s-at-home/charts/tree/master/charts/frigate repo
* The `charts/frigate/ci/ci-values.yaml` uses a public mqtt server and forces a CPU detector in order to facilitate successful test installation of the chart within an action
* The chart was updated to reflect changes in https://github.com/k8s-at-home/charts/pull/510 to support frigate v0.8.0
* The example frigate config in `values.yaml` is very sparse with a reference to the frigate configuration documentation for additional configuration options