### PR TITLE
feat: Update Environment Variables, DOCs and Default Detector

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.0"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 5.0.1
+version: 5.0.2
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/INSTALL.md
+++ b/charts/frigate/INSTALL.md
@@ -1,0 +1,78 @@
+# Frigate - NVR With Realtime Object Detection for IP Cameras
+
+This is a helm chart for [frigate](https://github.com/blakeblackshear/frigate)
+
+## TL;DR;
+
+```shell
+$ helm repo add blakeshome https://blakeblackshear.github.io/blakeshome-charts/
+$ helm install blakeshome/frigate
+```
+
+## Requirements
+MQTT server in either thesame namespace or reachable via IP or FQDN
+
+## Installing the Chart
+
+To install the chart with the release name `frigate`:
+
+### Create credentials seceret
+```console
+kc create secret generic frigate-rstp-credentials --from-literal=FRIGATE_RTSP_USERNAME=<username> --from-literal=FRIGATE_RTSP_PASSWORD=<password> -n <namespace>
+```
+
+### Install MQTT is not already available
+```console
+helm install mosquitto k8s-at-home/mosquitto
+```
+
+### Install Frigate
+```console
+helm install frigate blakeshome/frigate
+```
+
+If using the Coral USB TPU module (strongly recommended), you can use `nodeAffinity` rules to designate which node the pod is scheduled to in order to have host-access to the device, for example:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: tpu
+          operator: In
+          values:
+          - google-coral
+```
+
+... where a node with an attached Coral USB device is labeled with `tpu: google-coral`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `frigate` deployment:
+
+```console
+helm delete frigate
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](https://github.com/blakeblackshear/blakeshome-charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.
+
+Also reference https://blakeblackshear.github.io/frigate/configuration/index for detailed frigate configuration settings.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install frigate \
+  --set rtspPassword="someValue" \
+    blakeshome/frigate
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name frigate -f values.yaml blakeshome/frigate
+```

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -1,64 +1,76 @@
-# Frigate - NVR With Realtime Object Detection for IP Cameras
+# frigate
 
-This is a helm chart for [frigate](https://github.com/blakeblackshear/frigate)
+![Version: 5.0.2](https://img.shields.io/badge/Version-5.0.2-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
-## TL;DR;
+NVR With Realtime Object Detection for IP Cameras
 
-```shell
-$ helm repo add blakeshome https://blakeblackshear.github.io/blakeshome-charts/
-$ helm install blakeshome/frigate
-```
+**Homepage:** <https://github.com/blakeblackshear/blakeshome-charts/tree/master/charts/frigate>
 
-## Installing the Chart
+## Maintainers
 
-To install the chart with the release name `frigate`:
+| Name | Email | Url |
+| ---- | ------ | --- |
+| blakeblackshear | blakeb@blakeshome.com |  |
+| billimek | jeff@billimek.com |  |
 
-```console
-helm install frigate blakeshome/frigate
-```
+## Source Code
 
-If using the Coral USB TPU module (strongly recommended), you can use `nodeAffinity` rules to designate which node the pod is scheduled to in order to have host-access to the device, for example:
+* <https://github.com/blakeblackshear/frigate>
 
-```yaml
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: tpu
-          operator: In
-          values:
-          - google-coral
-```
+## Values
 
-... where a node with an attached Coral USB device is labeled with `tpu: google-coral`
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| config | string | `"mqtt:\n  # Required: host name\n  host: mosquitto\n  # Optional: port (default: shown below)\n  port: 1883\n  # Optional: topic prefix (default: shown below)\n  # WARNING: must be unique if you are running multiple instances\n  topic_prefix: frigate\n  # Optional: client id (default: shown below)\n  # WARNING: must be unique if you are running multiple instances\n  client_id: frigate\n  # Optional: user\n  user: mqtt_user\n  # Optional: password\n  # NOTE: Environment variables that begin with 'FRIGATE_' may be referenced in {}.\n  #       eg. password: '{FRIGATE_MQTT_PASSWORD}'\n  password: password\n  # Optional: interval in seconds for publishing stats (default: shown below)\n  stats_interval: 60\n\ndetectors:\n  # coral:\n  #   type: edgetpu\n  #   device: usb\n  cpu1:\n    type: cpu\n\n# cameras:\n#   # Name of your camera\n#   front_door:\n#     ffmpeg:\n#       inputs:\n#         - path: rtsp://{FRIGATE_RSTP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2\n#           roles:\n#             - detect\n#             - rtmp\n#     width: 1280\n#     height: 720\n#     fps: 5\n"` |  |
+| coral.enabled | bool | `false` |  |
+| coral.hostPath | string | `"/dev/bus/usb"` |  |
+| env | list | `[]` |  |
+| envFromSecrets[0] | string | `"frigate-rstp-credentials"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"blakeblackshear/frigate"` |  |
+| image.tag | string | `"0.8.0-amd64"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0] | string | `"chart-example.local"` |  |
+| ingress.path | string | `"/"` |  |
+| ingress.tls | list | `[]` |  |
+| initContainer.image.pullPolicy | string | `"Always"` |  |
+| initContainer.image.repository | string | `"busybox"` |  |
+| initContainer.image.tag | string | `"latest"` |  |
+| masksConfigMap | object | `{}` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| persistence.data.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.data.enabled | bool | `false` |  |
+| persistence.data.size | string | `"10Gi"` |  |
+| persistence.data.skipuninstall | bool | `false` |  |
+| podAnnotations | object | `{}` |  |
+| probes.liveness.enabled | bool | `true` |  |
+| probes.liveness.failureThreshold | int | `5` |  |
+| probes.liveness.initialDelaySeconds | int | `30` |  |
+| probes.liveness.timeoutSeconds | int | `10` |  |
+| probes.readiness.enabled | bool | `true` |  |
+| probes.readiness.failureThreshold | int | `5` |  |
+| probes.readiness.initialDelaySeconds | int | `30` |  |
+| probes.readiness.timeoutSeconds | int | `10` |  |
+| probes.startup.enabled | bool | `false` |  |
+| probes.startup.failureThreshold | int | `30` |  |
+| probes.startup.periodSeconds | int | `10` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.labels | object | `{}` |  |
+| service.loadBalancerIP | string | `nil` |  |
+| service.port | int | `5000` |  |
+| service.type | string | `"ClusterIP"` |  |
+| shmSize | string | `"1Gi"` |  |
+| strategyType | string | `"Recreate"` |  |
+| tolerations | list | `[]` |  |
 
-## Uninstalling the Chart
-
-To uninstall/delete the `frigate` deployment:
-
-```console
-helm delete frigate
-```
-
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Configuration
-
-Read through the [values.yaml](https://github.com/blakeblackshear/blakeshome-charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.
-
-Also reference https://blakeblackshear.github.io/frigate/configuration/index for detailed frigate configuration settings.
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```console
-helm install frigate \
-  --set rtspPassword="someValue" \
-    blakeshome/frigate
-```
-
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
-
-```console
-helm install --name frigate -f values.yaml blakeshome/frigate
-```
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -97,14 +97,12 @@ spec:
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           {{- end }}
           env:
-            {{- if .Values.timezone }}
-            - name: TZ
-              value: "{{ .Values.timezone }}"
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
             {{- end }}
-            - name: FRIGATE_RTSP_PASSWORD
-              value: "{{ .Values.rtspPassword }}"
           envFrom:
-          {{- range .Values.extraSecretForEnvFrom }}
+          {{- range .Values.envFromSecrets }}
             - secretRef:
                 name: {{ . }}
           {{- end }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -12,10 +12,12 @@ image:
   tag: 0.8.0-amd64
   pullPolicy: IfNotPresent
 
-rtspPassword: password
+env: {}
+  # TZ: UTC
 
-# secret name containing environment variables for frigate
-extraSecretForEnvFrom: []
+envFromSecrets: []
+  # secrets are required before `helm install`
+  # - frigate-rstp-credentials
 
 coral:
   enabled: false
@@ -65,18 +67,18 @@ config: |
     stats_interval: 60
 
   detectors:
-    coral:
-      type: edgetpu
-      device: usb
-    # cpu1:
-    #   type: cpu
+    # coral:
+    #   type: edgetpu
+    #   device: usb
+    cpu1:
+      type: cpu
 
   # cameras:
   #   # Name of your camera
   #   front_door:
   #     ffmpeg:
   #       inputs:
-  #         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
+  #         - path: rtsp://{FRIGATE_RSTP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
   #           roles:
   #             - detect
   #             - rtmp
@@ -164,9 +166,11 @@ resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
+  #   gpu.intel.com/i915: 1
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+  #   gpu.intel.com/i915: 1
 
 nodeSelector: {}
 


### PR DESCRIPTION
Enables seamless use of secrets to pass credentials for RSTP streams.  Previous use of rstpPassword in the values.yaml file does not allow for secure storage of the credentials and when attempting to use secrets to do so the existing template still creates `FRIGATE_RSTP_PASSWORD`.

Updates
  - Users can now pass in credentials via `env` or `envFromSecrets`
  - Docs generated with helm-docs (README.MD)
  - original README.md changed to INSTALL,md
  - Details on how to create secrets added
  - Details on install for MQTT added
  - default detector now CPU, first time users without coral will benefit from less troubleshooting
  - version bump
