### PR TITLE
Fix broken mount of frigate config map

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.0"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.0.0
+version: 6.0.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -98,8 +98,6 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: config
-          emptyDir: {}
-        - name: configmap
           configMap:
             name: {{ template "frigate.fullname" . }}
         {{- if .Values.coral.enabled }}


### PR DESCRIPTION
Turns out the init container which was removed also moved the configmap around. I'm on vacation so I didn't have time to run any testing. Sorry about that. cc @onedr0p  