### PR TITLE
Adding imageTag helper

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.4"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.1.1
+version: 6.2.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.4"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.1.0
+version: 6.1.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/_helpers.tpl
+++ b/charts/frigate/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Gets the image Tag to use when pulling the docker image
+*/}}
+{{- define "frigate.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{ .Values.image.tag }}
+{{- else -}}
+{{ .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ include "frigate.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -9,6 +9,7 @@ strategyType: Recreate
 
 image:
   repository: blakeblackshear/frigate
+  # -- Overrides the default tag (appVersion) used in Chart.yaml
   tag: 0.9.4-amd64
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This PR will serve as the basis to fix #24. Unfortunately, the Frigate Docker image is not built with multi-arch and instead is built separately with a unique tag to denote each CPU architecture. Because of this, the tag or more importantly the image pull, cannot be done in a standard fashion.

This means:
- user must know the specific cpu architecture for the node the container will land on
- User needs to lookup the proper tag to use
- Will not allow for K8s deployments in a mixed architecture environment
- Harder to manage updates
- More config options a user must input to get started

With a multi-arch Docker image, the daemon automatically pulls the proper image for the CPU architecture and thus having a single tag. I've created a new issue [here](https://github.com/blakeblackshear/frigate/issues/2592)