### PR TITLE
bump default frigate tag to 0.11.0

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.10.1"
+appVersion: "0.11.0"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
 version: 6.4.1

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.0"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.4.1
+version: 7.0.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Docker registry/repository to pull the image from
   repository: blakeblackshear/frigate
   # -- Overrides the default tag (appVersion) used in Chart.yaml ([Docker Hub](https://hub.docker.com/r/blakeblackshear/frigate/tags?page=1))
-  tag: 0.10.1-amd64
+  tag: 0.11.0
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The default tag will now also work for amd64 & armv8.