### PR TITLE
Fix #35 - Device path for non-usb coral

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.3.1
+version: 6.4.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -97,8 +97,8 @@ spec:
           {{- end }}
           volumeMounts:
             {{- if .Values.coral.enabled }}
-            - mountPath: /dev/bus/usb
-              name: usb
+            - mountPath: {{ .Values.coral.hostPath }}
+              name: coralDev
             {{- end }}
             - mountPath: /config
               name: config
@@ -120,7 +120,7 @@ spec:
           configMap:
             name: {{ template "frigate.fullname" . }}
         {{- if .Values.coral.enabled }}
-        - name: usb
+        - name: coralDev
           hostPath:
             path: {{ .Values.coral.hostPath }}
         {{- end }}


### PR DESCRIPTION
Fix #35 