### PR TITLE
Bump chart version, and fix invalid name that lint didnt pickup

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.4.0
+version: 6.4.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
           volumeMounts:
             {{- if .Values.coral.enabled }}
             - mountPath: {{ .Values.coral.hostPath }}
-              name: coralDev
+              name: coral-dev
             {{- end }}
             - mountPath: /config
               name: config
@@ -120,7 +120,7 @@ spec:
           configMap:
             name: {{ template "frigate.fullname" . }}
         {{- if .Values.coral.enabled }}
-        - name: coralDev
+        - name: coral-dev
           hostPath:
             path: {{ .Values.coral.hostPath }}
         {{- end }}


### PR DESCRIPTION
coarlDev wasnt allowed and wasn't detected by helm lint. I've fixed and tested via actual deployment this time ( i didnt before as i thought the lint would be good enough.