### PR TITLE
feat(ports): Add extra ports

### DIFF
--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -50,6 +50,12 @@ spec:
             - name: rtmp
               containerPort: 1935
               protocol: TCP
+            - name: RTSP
+              containerPort: 8554
+              protocol: TCP
+            - name: WebRTC
+              containerPort: 8555
+              protocol: TCP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:


### PR DESCRIPTION
I have added some extra ports that frigate recently added to their image. RTMP is depreciated, use instead the go2rtc for more info: https://docs.frigate.video/configuration/restream