### PR TITLE
support webrtc

### DIFF
--- a/charts/frigate/templates/service.yaml
+++ b/charts/frigate/templates/service.yaml
@@ -51,6 +51,14 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
+    - name: webrtc
+      port: 8555
+      protocl: TCP
+      targetPort: webrtc
+    - name: 8555-udp
+      port: 8555
+      protocl: UDP
+      targetPort: 8555
   selector:
     app.kubernetes.io/name: {{ include "frigate.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
I'm not well-versed in Helm, and I haven't had a chance to validate the suggested modifications. However, I applied a patch to my Kubernetes service directly, configuring it to support WebRTC with a LoadBalancer service type.

I'm uncertain whether it's advisable to enable the WebRTC section exclusively when using a LoadBalancer service type. Initially, my intention was simply to raise an issue requesting WebRTC support. Surprisingly, I experimented with this approach, and it successfully functioned on my microk8s instance.