### PR TITLE
Mount config into `subPath` to support Frigate 0.13

### DIFF
--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -33,6 +33,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      # initContainers:
+      #   - name: "{{ .Chart.Name }}-copy-configmap"
+      #     image: busybox
+      #     imagePullPolicy: IfNotPresent
+      #     command:
+      #       - "sh"
+      #       - "-c"
+      #       - |
+      #         cp /frigate-config/config.yml /config/config.yml
+      #     volumeMounts:
+      #       - name: config
+      #         mountPath: /frigate-config
+      #       - name: config-store
+      #         mountPath: /config
+      #     securityContext:
+      #       runAsUser: 0
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ include "frigate.imageTag" . }}"
@@ -100,7 +116,8 @@ spec:
             - mountPath: {{ .Values.coral.hostPath }}
               name: coral-dev
             {{- end }}
-            - mountPath: /config
+            - mountPath: /config/config.yml
+              subPath: config.yml
               name: config
             - mountPath: /data
               name: data
@@ -119,6 +136,9 @@ spec:
         - name: config
           configMap:
             name: {{ template "frigate.fullname" . }}
+        # - name: config-store
+        #   persistentVolumeClaim:
+        #     claimName: {{ .Values.configExistingClaim }}
         {{- if .Values.coral.enabled }}
         - name: coral-dev
           hostPath:

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -33,22 +33,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      # initContainers:
-      #   - name: "{{ .Chart.Name }}-copy-configmap"
-      #     image: busybox
-      #     imagePullPolicy: IfNotPresent
-      #     command:
-      #       - "sh"
-      #       - "-c"
-      #       - |
-      #         cp /frigate-config/config.yml /config/config.yml
-      #     volumeMounts:
-      #       - name: config
-      #         mountPath: /frigate-config
-      #       - name: config-store
-      #         mountPath: /config
-      #     securityContext:
-      #       runAsUser: 0
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ include "frigate.imageTag" . }}"
@@ -136,9 +120,6 @@ spec:
         - name: config
           configMap:
             name: {{ template "frigate.fullname" . }}
-        # - name: config-store
-        #   persistentVolumeClaim:
-        #     claimName: {{ .Values.configExistingClaim }}
         {{- if .Values.coral.enabled }}
         - name: coral-dev
           hostPath:


### PR DESCRIPTION
Since vacuums have been introduced and the path is not configurable, we need to allow another volume to be mounted into `/config` so that `/config/.vaccum` can be written to. To do this, we can utilize `extraVolumes` and `extraVolumeMounts` but we will need to mount the Frigate configuration into a `subPath` so that the `mountPath` does not conflict.

Related PR: https://github.com/blakeblackshear/frigate/pull/6712/files#diff-15e7eac9ac660180d8d6be2ce993db57a3f8aa5d4b2a02333254024b6add7eb4R175