### PR TITLE
Update chart for Frigate v0.13

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.12.0"
+appVersion: "0.13.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.2.0
+version: 7.3.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -1,6 +1,6 @@
 # frigate
 
-![Version: 7.0.1](https://img.shields.io/badge/Version-7.0.1-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 7.3.0](https://img.shields.io/badge/Version-7.3.0-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
 
 NVR With Realtime Object Detection for IP Cameras
 
@@ -40,10 +40,6 @@ config: |
           - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
             roles:
               - detect
-              - rtmp
-      detect:
-        width: 1280
-        height: 720
 ```
 
 #### Install Chart
@@ -72,7 +68,7 @@ helm upgrade --install \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Set Pod affinity rules |
-| config | string | `"mqtt:\n  # Required: host name\n  host: mqtt.server.com\n  # Optional: port (default: shown below)\n  port: 1883\n  # Optional: topic prefix (default: shown below)\n  # WARNING: must be unique if you are running multiple instances\n  topic_prefix: frigate\n  # Optional: client id (default: shown below)\n  # WARNING: must be unique if you are running multiple instances\n  client_id: frigate\n  # Optional: user\n  user: mqtt_user\n  # Optional: password\n  # NOTE: Environment variables that begin with 'FRIGATE_' may be referenced in {}.\n  #       eg. password: '{FRIGATE_MQTT_PASSWORD}'\n  password: password\n  # Optional: interval in seconds for publishing stats (default: shown below)\n  stats_interval: 60\n\ndetectors:\n  # coral:\n  #   type: edgetpu\n  #   device: usb\n  cpu1:\n    type: cpu\n\n# cameras:\n#   # Name of your camera\n#   front_door:\n#     ffmpeg:\n#       inputs:\n#         - path: rtsp://{FRIGATE_RSTP_USERNAME}:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2\n#           roles:\n#             - detect\n#             - rtmp\n#     width: 1280\n#     height: 720\n#     fps: 5\n"` | frigate configuration - see [Docs](https://docs.frigate.video/configuration/index) for more info |
+| config | string | Omitted for brevity. See [values.yaml](./values.yaml). | frigate configuration - see [Docs](https://docs.frigate.video/configuration/index) for more info |
 | coral.enabled | bool | `false` | enables the use of a Coral device |
 | coral.hostPath | string | `"/dev/bus/usb"` | path on the host to which to mount the Coral device |
 | env | object | `{}` | additional ENV variables to set. Prefix with FRIGATE_ to target Frigate configuration values |
@@ -92,10 +88,15 @@ helm upgrade --install \
 | ingress.tls | list | `[]` | list of TLS configurations |
 | nameOverride | string | `""` | Overrides the name of resources |
 | nodeSelector | object | `{}` | Node Selector configuration |
-| persistence.data.accessMode | string | `"ReadWriteOnce"` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC |
-| persistence.data.enabled | bool | `false` | Enables persistence for the data directory |
-| persistence.data.size | string | `"10Gi"` | size/capacity of the PVC |
-| persistence.data.skipuninstall | bool | `false` | Do not delete the pvc upon helm uninstall |
+| persistence.data.* | | | **This config key is obsolete and should not be used. Use `persistence.media.*` and `persistence.config.*` instead.** |
+| persistence.config.enabled | bool | `false` | Enables persistence for the data directory |
+| persistence.config.size | string | `"10Gi"` | size/capacity of the PVC |
+| persistence.config.skipuninstall | bool | `false` | Do not delete the pvc upon helm uninstall |
+| persistence.config.accessMode | string | `"ReadWriteOnce"` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC |
+| persistence.media.enabled | bool | `false` | Enables persistence for the data directory |
+| persistence.media.size | string | `"10Gi"` | size/capacity of the PVC |
+| persistence.media.skipuninstall | bool | `false` | Do not delete the pvc upon helm uninstall |
+| persistence.media.accessMode | string | `"ReadWriteOnce"` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC |
 | podAnnotations | object | `{}` | Set additonal pod Annotations |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.failureThreshold | int | `5` |  |

--- a/charts/frigate/templates/config-pvc.yaml
+++ b/charts/frigate/templates/config-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "frigate.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "frigate.name" . }}
+    helm.sh/chart: {{ include "frigate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -103,8 +103,9 @@ spec:
             - mountPath: {{ .Values.coral.hostPath }}
               name: coral-dev
             {{- end }}
-            - mountPath: /config
-              name: config
+            - mountPath: /config/config.yml
+              subPath: config.yml
+              name: configmap
             - mountPath: /data
               name: data
             - mountPath: /media
@@ -121,7 +122,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
             {{- end }}
       volumes:
-        - name: config
+        - name: configmap
           configMap:
             name: {{ template "frigate.fullname" . }}
         {{- if .Values.coral.enabled }}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
               name: config
             - mountPath: /data
               name: data
+            - mountPath: /media
+              name: media
             - name: dshm
               mountPath: /dev/shm
             {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
@@ -131,6 +133,13 @@ spec:
         {{- if .Values.persistence.data.enabled }}
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.data.existingClaim }}{{ .Values.persistence.data.existingClaim }}{{- else }}{{ template "frigate.fullname" . }}-data{{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: media
+        {{- if .Values.persistence.media.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "frigate.fullname" . }}-media{{- end }}
         {{- else }}
           emptyDir: {}
         {{- end }}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -106,6 +106,8 @@ spec:
             - mountPath: /config/config.yml
               subPath: config.yml
               name: configmap
+            - mountPath: /config
+              name: config
             - mountPath: /data
               name: data
             - mountPath: /media
@@ -129,6 +131,13 @@ spec:
         - name: coral-dev
           hostPath:
             path: {{ .Values.coral.hostPath }}
+        {{- end }}
+        - name: config
+        {{- if .Values.persistence.config.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "frigate.fullname" . }}-config{{- end }}
+        {{- else }}
+          emptyDir: {}
         {{- end }}
         - name: data
         {{- if .Values.persistence.data.enabled }}

--- a/charts/frigate/templates/media-pvc.yaml
+++ b/charts/frigate/templates/media-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "frigate.fullname" . }}-media
+  {{- if .Values.persistence.media.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "frigate.name" . }}
+    helm.sh/chart: {{ include "frigate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.media.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.media.size | quote }}
+{{- if .Values.persistence.media.storageClass }}
+{{- if (eq "-" .Values.persistence.media.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.media.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -192,6 +192,32 @@ persistence:
     # -- Do not delete the pvc upon helm uninstall
     skipuninstall: false
 
+  media:
+    # -- Enables persistence for the media directory
+    enabled: false
+    ## frigate data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+
+    # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC
+    accessMode: ReadWriteOnce
+
+    # -- size/capacity of the PVC
+    size: 10Gi
+
+    # -- Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+
 # -- Set resource limits/requests for the Pod(s)
 resources: {}
   # limits:

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -194,7 +194,7 @@ persistence:
     accessMode: ReadWriteOnce
 
     # -- size/capacity of the PVC
-    size: 200Mi
+    size: 100Mi
 
     # -- Do not delete the pvc upon helm uninstall
     skipuninstall: false

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -192,6 +192,32 @@ persistence:
     # -- Do not delete the pvc upon helm uninstall
     skipuninstall: false
 
+  config:
+    # -- Enables persistence for the config directory
+    enabled: false
+    ## frigate data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+
+    # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC
+    accessMode: ReadWriteOnce
+
+    # -- size/capacity of the PVC
+    size: 200Mi
+
+    # -- Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+
   media:
     # -- Enables persistence for the media directory
     enabled: false

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -167,29 +167,10 @@ ingress:
 
 persistence:
   data:
-    # -- Enables persistence for the data directory
+    # Data directory is obsolete. Use config and media instead.
     enabled: false
-    ## frigate data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    # storageClass: "-"
-    ##
-    ## If you want to reuse an existing claim, you can pass the name of the PVC using
-    ## the existingClaim variable
-    # existingClaim: your-claim
-    # subPath: some-subpath
-
-    # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC
     accessMode: ReadWriteOnce
-
-    # -- size/capacity of the PVC
     size: 10Gi
-
-    # -- Do not delete the pvc upon helm uninstall
     skipuninstall: false
 
   config:


### PR DESCRIPTION
Pulling together code from #9, #44 and #51 to better support Frigate v0.13

- Adds options for media persistence
- Adds options for config persistence
- Modifies configmap to use subpath to allow volume nesting
  - This avoids the need to change the default database path
- Retains the data directory persistence but adds a note that this is obsolete
  - Allows those who were changing the database path to `/data` to continue doing so

The additional configuration needed for full persistence is:

```yaml
persistence:
  config:
    enabled: true
  media:
    enabled: true
```

The options for config and media are identical to data. I'd prefer a different name for `config` to better identify that it is storing the database and other working files, but I'm not sure what that would be. Open to suggestions.

Config has been tested on my local cluster. I haven't yet checked media.
