### PR TITLE
deploy `Chart.appVersion` by default and generate valid `resources`

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.13.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.3.0
+version: 7.3.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/_helpers.tpl
+++ b/charts/frigate/templates/_helpers.tpl
@@ -54,3 +54,16 @@ Gets the image Tag to use when pulling the docker image
 {{ .Chart.AppVersion }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate resources spec block in order to merge nvidia specific settings with user defined
+*/}}
+{{- define "frigate.resources" -}}
+{{- $resources := .Values.resources | default dict -}}
+{{- $nvidiaresources := dict "nvidia.com/gpu" 1 -}}
+{{- $nvidiaLimits := dict "limits" $nvidiaresources -}}
+{{- if .Values.gpu.nvidia.enabled -}}
+{{- $resources := mergeOverwrite $resources $nvidiaLimits -}}
+{{- end -}}
+{{ $resources | toYaml }}
+{{- end -}}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -116,13 +116,7 @@ spec:
               mountPath: /dev/shm
             {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
           resources:
-            {{- if .Values.gpu.nvidia.enabled }}
-            limits:
-              "nvidia.com/gpu": 1
-            {{- end }}
-            {{- if .Values.resources }}
-            {{- toYaml .Values.resources | nindent 12 }}
-            {{- end }}
+            {{- include "frigate.resources" . | nindent 12 }}
       volumes:
         - name: configmap
           configMap:

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Docker registry/repository to pull the image from
   repository: ghcr.io/blakeblackshear/frigate
   # -- Overrides the default tag (appVersion) used in Chart.yaml ([Docker Hub](https://hub.docker.com/r/blakeblackshear/frigate/tags?page=1))
-  tag: 0.12.0
+  tag:
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
While `Chart.appVersion` is set to `0.13.1` `image.tag` was `0.12.0` so effectively the older version is deployed by default.

Having the ability to override the default tag is great but it should be empty by default to simplify chart maintenance and avoid confusion.

Also fixed `resources` block with `gpu.nvidia.enabled` and user-defined `resources`, was failing with:
```
unmarshal errors:
 line 89: mapping key "limits" already defined at line 87
```