### PR TITLE
Disable heathchecks for old NVIDIA GPU

### DIFF
--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -78,6 +78,7 @@ helm upgrade --install \
 | fullnameOverride | string | `""` | Overrides the Full Name of resources |
 | gpu.nvidia.enabled | bool | `false` | Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image |
 | gpu.nvidia.runtimeClassName | string | `nil` | Overrides the default runtimeClassName |
+| gpu.nvidia.disableHealthchecks | bool | `false` | Disable XID errors healthchecks for old NVIDIA GPU compatiblity |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"ghcr.io/blakeblackshear/frigate"` | Docker registry/repository to pull the image from |
 | image.tag | string | `"0.12.0"` | Overrides the default tag (appVersion) used in Chart.yaml ([Docker Hub](https://hub.docker.com/r/blakeblackshear/frigate/tags?page=1)) |

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
             - name: NVIDIA_VISIBLE_DEVICES
               value: "all"
             {{- end }}
+            {{- if .Values.gpu.nvidia.disableHealthchecks }}
+            - name: DP_DISABLE_HEALTHCHECKS
+              value: "xids"
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -35,9 +35,10 @@ gpu:
   nvidia:
     # -- Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image
     enabled: false
-
     # -- Overrides the default runtimeClassName
     runtimeClassName:
+    # Disable XID errors healthchecks for old NVIDIA GPU compatiblity 
+    disableHealthchecks: false
 
 # -- declare extra volumes to use for Frigate
 extraVolumes: []


### PR DESCRIPTION
Some old NVIDIA GPU might be to old to be healtchecked, that results in an error "0/1 nodes are available: 1 Insufficient nvidia.com/gpu"
A workaround is to disable XID errors health checks with DP_DISABLE_HEALTHCHECKS=xids ENV property.
I added a helm value to optionally add this ENV property to the Pod.