### PR TITLE
Add support for /tmp mount backed by tmpfs/memory

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.13.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.4.0
+version: 7.5.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
         - name: tmp
           emptyDir:
             medium: Memory
-            sizeLimit: { { .Values.tmpfs.sizeLimit } }
+            sizeLimit: {{ .Values.tmpfs.sizeLimit }}
         {{- end }}
         {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
       {{- with .Values.nodeSelector }}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
               name: media
             - name: dshm
               mountPath: /dev/shm
+            {{- if .Values.tmpfs.enabled }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
           resources:
             {{- if .Values.gpu.nvidia.enabled }}
@@ -157,6 +161,12 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.shmSize }}
+        {{- if .Values.tmpfs.enabled }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: { { .Values.tmpfs.sizeLimit } }
+        {{- end }}
         {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -47,6 +47,11 @@ extraVolumeMounts: []
 # -- amount of shared memory to use for caching
 shmSize: 1Gi
 
+# -- use memory for tmpfs (mounted to /tmp)
+tmpfs:
+  enabled: true
+  sizeLimit: 1Gi
+
 # nameOverride -- Overrides the name of resources
 nameOverride: ""
 


### PR DESCRIPTION
Related to https://github.com/blakeblackshear/blakeshome-charts/issues/66
Add support for optional /tmp mount backed by tmpfs/memory