### PR TITLE
Expose port used by WebRTC

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.14.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.7.0
+version: 7.7.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -53,6 +53,12 @@ spec:
             - name: rtsp
               containerPort: 8554
               protocol: TCP
+            - name: webrtc-udp
+              containerPort: 8555
+              protocol: UDP
+            - name: webrtc-tcp
+              containerPort: 8555
+              protocol: TCP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/frigate/templates/service.yaml
+++ b/charts/frigate/templates/service.yaml
@@ -63,6 +63,14 @@ spec:
       protocol: TCP
       targetPort: rtsp
       {{/* TODO: think of making the nodePort ability available, the rtmp solution from above would not work as you can't use the same port multiple times */}}
+    - name: webrtc-tcp
+      port: 8555
+      protocol: TCP
+      targetPort: webrtc-tcp
+    - name: webrtc-udp
+      port: 8555
+      protocol: UDP
+      targetPort: webrtc-udp
   selector:
     app.kubernetes.io/name: {{ include "frigate.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Resolves #59.

I was also wondering if it would be a good idea to add an option to create a separate service for WebRTC (and possibly RTSP), since right now if the main service is a `ClusterIP` consumed by some sort of reverse proxy, then these ports aren't accessible by someone outside of the cluster.