### PR TITLE
Adapt GPU use case

### DIFF
--- a/charts/frigate/templates/_helpers.tpl
+++ b/charts/frigate/templates/_helpers.tpl
@@ -54,16 +54,3 @@ Gets the image Tag to use when pulling the docker image
 {{ .Chart.AppVersion }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Generate resources spec block in order to merge nvidia specific settings with user defined
-*/}}
-{{- define "frigate.resources" -}}
-{{- $resources := .Values.resources | default dict -}}
-{{- $nvidiaresources := dict "nvidia.com/gpu" 1 -}}
-{{- $nvidiaLimits := dict "limits" $nvidiaresources -}}
-{{- if .Values.gpu.nvidia.enabled -}}
-{{- $resources := mergeOverwrite $resources $nvidiaLimits -}}
-{{- end -}}
-{{ $resources | toYaml }}
-{{- end -}}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -122,8 +122,10 @@ spec:
               mountPath: /tmp
             {{- end }}
             {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
+          {{- if .Values.resources }}
           resources:
-            {{- include "frigate.resources" . | nindent 12 }}
+                {{- .Values.resources | toYaml | nindent 12 }}
+          {{- end }}
       volumes:
         - name: configmap
           configMap:

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -133,10 +133,8 @@ spec:
               mountPath: /tmp
             {{- end }}
             {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
-          {{- if .Values.resources }}
           resources:
                 {{- .Values.resources | toYaml | nindent 12 }}
-          {{- end }}
       volumes:
         - name: configmap
           configMap:

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -26,8 +26,19 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- if and .Values.gpu.nvidia.enabled (.Values.gpu.nvidia.runtimeClassName) }}
+      {{- if and .Values.gpu.nvidia.enabled }}
+      {{- if .Values.gpu.nvidia.runtimeClassName }}
       runtimeClassName: {{ .Values.gpu.nvidia.runtimeClassName }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "nvidia.com/gpu.present"
+                operator: In
+                values:
+                - "true"
       {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Hi there,

Just sharing little adjust I had to make for my case.

The chart enforces a limits of 1 gpu if enabled. I understand to force the pod to use a node with that resource.
As there is no gpu request, and cannot be lower than 1, this is in reality requesting 1 dedicated GPU.

In my particular case, there is only 1 node with 1 GPU that everyone shares and this cannot run.

I´ve removed that enforced limit of 1 GPU and add nodeAffinity to ensure the pod is scheduled on a proper node
You still can customize the request via values.yaml