### PR TITLE
Add ephemeral writable config.yml support

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.6.0
+version: 7.7.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -42,6 +42,19 @@ config: |
               - detect
 ```
 
+#### Configuration Updates
+
+Since the config key is stored in a configMap which is mounted as a read-only file, the Frigate UI
+will be unable to update the configuration, and config migration will fail.
+
+If `persistence.config.ephemeralWritableConfigYaml` is set to true along with `persistence.config.enabled`,
+the config.yml will be copied into the /config volume mount rather than mounted into it.
+
+Copying the config file means migrations can run, and updates to settings, zones, etc.. will be
+written to the running configuration. **However** as soon as the pod is restarted, the changes
+will be lost, so you will have to retrieve the config.yml either from the pod, or
+by performing a `GET /api/config` and updating your helm values `config` key with the new yaml.
+
 #### Install Chart
 
 Now install the chart:

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -106,6 +106,7 @@ helm upgrade --install \
 | persistence.config.size | string | `"10Gi"` | size/capacity of the PVC |
 | persistence.config.skipuninstall | bool | `false` | Do not delete the pvc upon helm uninstall |
 | persistence.config.accessMode | string | `"ReadWriteOnce"` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC |
+| persistence.config.ephemeralWritableConfigYaml | bool | `true` | Copy config into volume mount for writable ephemeral config support |
 | persistence.media.enabled | bool | `false` | Enables persistence for the data directory |
 | persistence.media.size | string | `"10Gi"` | size/capacity of the PVC |
 | persistence.media.skipuninstall | bool | `false` | Do not delete the pvc upon helm uninstall |

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -33,6 +33,25 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if or .Values.extraInitContainers (and .Values.persistence.config.enabled .Values.persistence.config.ephemeralWritableConfigYaml) }}
+      initContainers:
+      {{- with .Values.extraInitContainers }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.persistence.config.enabled .Values.persistence.config.ephemeralWritableConfigYaml }}
+        - name: copyconfig
+          image: "{{ .Values.image.repository }}:{{ include "frigate.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /config.yml
+              subPath: config.yml
+              name: configmap
+            - mountPath: /config
+              name: config
+          command: [ "cp" ]
+          args: [ "-v", "/config.yml", "/config/config.yaml" ]
+      {{- end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ include "frigate.imageTag" . }}"
@@ -47,7 +66,7 @@ spec:
             - name: http
               containerPort: 5000
               protocol: TCP
-            - name: http-auth 
+            - name: http-auth
               containerPort: 8971
               protocol: TCP
             - name: rtmp
@@ -106,9 +125,11 @@ spec:
             - mountPath: {{ .Values.coral.hostPath }}
               name: coral-dev
             {{- end }}
+            {{- if not (and .Values.persistence.config.enabled .Values.persistence.config.ephemeralWritableConfigYaml) }}
             - mountPath: /config/config.yml
               subPath: config.yml
               name: configmap
+            {{- end }}
             - mountPath: /config
               name: config
             - mountPath: /data

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -162,7 +162,7 @@ ingress:
     # nginx.org/websocket-services: "<release_name>-frigate" # TODO: can this be automated?
 
   # -- list of hosts and their paths and ports that ingress controller should repsond to.
-  # -- alternatively use `http` if anonymous auth is allowed 
+  # -- alternatively use `http` if anonymous auth is allowed
   hosts:
     - host: chart.example.local
       paths:
@@ -208,6 +208,12 @@ persistence:
 
     # -- Do not delete the pvc upon helm uninstall
     skipuninstall: false
+
+    ## Copy configMap config into volume to make writable
+    ## All live changes are lost when pod restarts, but this allows
+    ## an easy way to run migrations and edit config, then scrape
+    ## it from the API or copy out of the pod and update local helm values
+    ephemeralWritableConfigYaml: true
 
   media:
     # -- Enables persistence for the media directory
@@ -267,3 +273,6 @@ affinity: {}
 
 # -- Set additonal pod Annotations
 podAnnotations: {}
+
+# -- Define extra init containers
+extraInitContainers: []


### PR DESCRIPTION
This change creates an initContainer that copies the config.yml from the
configMap into /config before frigate starts up. This allows config
migrations to run, and UI updates to function ephemerally (until the pod
restarts).
    
Generic support for extraInitContainers was also added.
    
Chart minor version bumped (new feature) and default tag moved to
1.14.1.