### PR TITLE
fix: Update outdated docker image registry info

### DIFF
--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -76,11 +76,11 @@ helm upgrade --install \
 | extraVolumeMounts | list | `[]` | declare additional volume mounts |
 | extraVolumes | list | `[]` | declare extra volumes to use for Frigate |
 | fullnameOverride | string | `""` | Overrides the Full Name of resources |
-| gpu.nvidia.enabled | bool | `false` | Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image |
+| gpu.nvidia.enabled | bool | `false` | Enables NVIDIA GPU compatibility. Must also use the "x.x.x-tensorrt" tagged image |
 | gpu.nvidia.runtimeClassName | string | `nil` | Overrides the default runtimeClassName |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"ghcr.io/blakeblackshear/frigate"` | Docker registry/repository to pull the image from |
-| image.tag | string | `"0.12.0"` | Overrides the default tag (appVersion) used in Chart.yaml ([Docker Hub](https://hub.docker.com/r/blakeblackshear/frigate/tags?page=1)) |
+| image.tag | string | `"0.12.0"` | Overrides the default tag (appVersion) used in Chart.yaml ([Github](https://github.com/blakeblackshear/frigate/pkgs/container/frigate)). See [the Github release page](https://github.com/blakeblackshear/frigate/releases) for more |
 | imagePullSecrets | list | `[]` | Docker image pull policy |
 | ingress.annotations | object | `{}` | annotations to configure your Ingress. See your Ingress Controller's Docs for more info. |
 | ingress.enabled | bool | `false` | Enables the use of an Ingress Controller to front the Service and can provide HTTPS |

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -8,7 +8,7 @@ strategyType: Recreate
 image:
   # -- Docker registry/repository to pull the image from
   repository: ghcr.io/blakeblackshear/frigate
-  # -- Overrides the default tag (appVersion) used in Chart.yaml ([Docker Hub](https://hub.docker.com/r/blakeblackshear/frigate/tags?page=1))
+  # -- Overrides the default tag (appVersion) used in Chart.yaml ([Github](https://github.com/blakeblackshear/frigate/pkgs/container/frigate)). See [the Github release page](https://github.com/blakeblackshear/frigate/releases) for more
   tag:
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
@@ -33,7 +33,7 @@ coral:
 
 gpu:
   nvidia:
-    # -- Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image
+    # -- Enables NVIDIA GPU compatibility. Must also use the "x.x.x-tensorrt" tagged image
     enabled: false
 
     # -- Overrides the default runtimeClassName


### PR DESCRIPTION
- They stopped using `amd64nvidia` as an image tag. [See the releases](https://github.com/blakeblackshear/frigate/releases).
- They're no longer using dockerhub but now [Github images](https://github.com/blakeblackshear/frigate/pkgs/container/frigate)