### PR TITLE
bump frigate chart version to 7.7.2 and fix config file path in deployment

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.14.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.7.1
+version: 7.7.2
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - mountPath: /config
               name: config
           command: [ "cp" ]
-          args: [ "-v", "/config.yml", "/config/config.yaml" ]
+          args: [ "-v", "/config.yml", "/config/config.yml" ]
       {{- end }}
     {{- end }}
       containers:


### PR DESCRIPTION
fixes #82

This pull request includes a version update and a minor fix to the `frigate` Helm chart.

Version update:

* [`charts/frigate/Chart.yaml`](diffhunk://#diff-4e1a6073921165bd0e5eecf5f0bdd4c3b709e6d6a78aedd907fe93ad10491287L5-R5): Updated the chart version from `7.7.1` to `7.7.2`.

Minor fix:

* [`charts/frigate/templates/deployment.yaml`](diffhunk://#diff-fab55a2ebafe0c123d8ab5d0ba00ee633f7fecb3ca7f7e145f5bed59b382ac13L52-R52): Corrected the file extension in the `args` parameter from `config.yaml` to `config.yml`.