### PR TITLE
Add option to define pod level SecurityContext

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.14.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.7.2
+version: 7.7.4
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.14.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.7.4
+version: 7.8.0
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+    {{- end }}
     {{- if or .Values.extraInitContainers (and .Values.persistence.config.enabled .Values.persistence.config.ephemeralWritableConfigYaml) }}
       initContainers:
       {{- with .Values.extraInitContainers }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -252,7 +252,7 @@ resources: {}
   #   memory: 128Mi
   #   gpu.intel.com/i915: 1
 
-# -- Set Security Context
+# -- Set Frigate Container Security Context
 securityContext: {}
   # capabilities:
   #   drop:
@@ -260,6 +260,19 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # privileged: true
+
+# -- Set Pod level Security Context
+# -- the container level securiy context defined above
+# -- will override it for frigate container
+podSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # fsGroup: 1000
   # privileged: true
 
 # -- Node Selector configuration


### PR DESCRIPTION
Makes it easy to define fsGroup to ensure all files are owned by given GID, which is not possible with container level SecuriyContext