### PR TITLE
add values to declare which GPU to use in a multi gpu setup

### DIFF
--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -90,6 +90,7 @@ helm upgrade --install \
 | extraVolumes | list | `[]` | declare extra volumes to use for Frigate |
 | fullnameOverride | string | `""` | Overrides the Full Name of resources |
 | gpu.nvidia.enabled | bool | `false` | Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image |
+| gpu.nvidia.gpu | string | `"all"` | declare which NVIDIA GPU to use. "all", index (as in output of nvidia-smi) or uuid |
 | gpu.nvidia.runtimeClassName | string | `nil` | Overrides the default runtimeClassName |
 | image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"ghcr.io/blakeblackshear/frigate"` | Docker registry/repository to pull the image from |

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: "all"
             - name: NVIDIA_VISIBLE_DEVICES
-              value: "all"
+              value: {{ .Values.gpu.nvidia.gpu }}
             {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -36,6 +36,9 @@ gpu:
     # -- Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image
     enabled: false
 
+    # -- Specify which NVIDIA GPU to use. "all", index (as shown in nvidia-smi output) or uuid
+    gpu: "all"
+
     # -- Overrides the default runtimeClassName
     runtimeClassName:
 


### PR DESCRIPTION
In a multi GPU setup it is not currently possible to specify which GPU to use as the `NVIDIA_VISIBLE_DEVICES` env var is hardcoded. This PR allows the user to specify which GPU to use and can be specified using "all" (default), the index of the GPU or the uuid. 