### PR TITLE
feat(deps): upgrade to frigate 0.16.1

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.14.1"
+appVersion: "0.16.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.8.0
+version: 7.9.0
 keywords:
   - tensorflow
   - coral


### PR DESCRIPTION
I had hard time to install my Raptor Lake GPU. It's related to the VA-API version 1.17.0 used in the actual chart version.
I forked the chart on my side and upgrade to frigate 0.16.1 and now using VA-API version: 1.22 it works like a charm.

I'm not sure I need any other modifications, maybe the value or something, let me know