### PR TITLE
feat(helm): enable template in config to allow passing secrets

### DIFF
--- a/charts/frigate/templates/configmap.yaml
+++ b/charts/frigate/templates/configmap.yaml
@@ -10,4 +10,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   config.yml: |
-{{ .Values.config | indent 4 }}
+{{ tpl .Values.config . | indent 4 }}


### PR DESCRIPTION
I want to be able to set my camera credentials in the config from my sops secret file.
The chart doesn't enable this behavior because it's getting the config as text and not as template.

My PR add this option by templating what's coming from the config. Let us pass values from helm inside the config. 