### PR TITLE
fix: Container resoures.limits values must be strings

### DIFF
--- a/charts/frigate/templates/_helpers.tpl
+++ b/charts/frigate/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Generate resources spec block in order to merge nvidia specific settings with us
 */}}
 {{- define "frigate.resources" -}}
 {{- $resources := .Values.resources | default dict -}}
-{{- $nvidiaresources := dict "nvidia.com/gpu" 1 -}}
+{{- $nvidiaresources := dict "nvidia.com/gpu" "1" -}}
 {{- $nvidiaLimits := dict "limits" $nvidiaresources -}}
 {{- if .Values.gpu.nvidia.enabled -}}
 {{- $resources := mergeOverwrite $resources $nvidiaLimits -}}


### PR DESCRIPTION
I was having trouble getting Frigate installed with [nixidy](https://github.com/arnarg/nixidy) and that's because the values of the resources.limits are expected to be strings as seen by the [generated spec here](https://github.com/arnarg/nixidy/blob/a9712b8a76d48d8711e774dbc7d03a83436a297a/modules/generated/k8s/v1.34.nix#L11148). Also as defined in swagger [here](https://github.com/kubernetes/kubernetes/blob/v1.34.2/api/openapi-spec/swagger.json):

```json
        "limits": {
          "additionalProperties": {
            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
          },
          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
          "type": "object"
        },
```

where Quantity is defined as:

```json
    "io.k8s.apimachinery.pkg.api.resource.Quantity": {
      "description": "Quantity is a fixed-point representation of a number. [...omitted]",
      "type": "string"
    },
```